### PR TITLE
Add gor-based traffic mirroring & replay.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ DS_Store
 .coverage
 dist/*
 *.egg-info/
-wq
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,16 @@ RUN apt-get update
 # Install python prerequisites
 RUN apt-get install -y python-pip python-dev build-essential
 
+# Install go
+RUN apt-get install -y golang
+
+# Install gor
+ENV GOPATH=/opt/go
+RUN mkdir -p $GOPATH \
+ && go get github.com/buger/gor \
+ && cd $GOPATH/src/github.com/buger/gor \
+ && go build
+
 # Install nginx
 ENV NGX_REQS openssl libssl1.0.0 libxml2 libxslt1.1 libgeoip1 libpcre3 zlib1g
 RUN apt-get update \
@@ -89,7 +99,6 @@ RUN mkdir -p /etc/nginx/sites-enabled \
  && mkdir -p /etc/nginx/sites-available \
  && mkdir -p /var/lib/nginx
 
-
 ######
 # System prerequisite configuration
 ######
@@ -104,6 +113,8 @@ RUN rm /etc/nginx/nginx.conf
 RUN mkdir -p /etc/aurproxy/nginx
 RUN ln -sf /etc/aurproxy/nginx/nginx.conf /etc/nginx
 
+# Create dynamic gor config location
+RUN mkdir -p /etc/aurproxy/gor
 
 ######
 # Application prerequisite installation

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,6 @@ gevent==1.0.1
 Jinja2==2.7.3
 kazoo==2.0
 librato-metrics==0.7.0
+psutil==2.2.1
 raven==5.1.1
 requests==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ Jinja2==2.7.3
 kazoo==2.0
 librato-metrics==0.7.0
 psutil==2.2.1
+python-dateutil==2.4.2
 raven==5.1.1
 requests==2.5.1

--- a/tellapart/aurproxy/backends/backend.py
+++ b/tellapart/aurproxy/backends/backend.py
@@ -17,6 +17,7 @@ from abc import (
   abstractmethod,
   abstractproperty)
 import copy
+import itertools
 
 from tellapart.aurproxy.config import (
   ProxyRoute,
@@ -144,6 +145,10 @@ class ProxyBackend(object):
                                **share_adjuster_kwargs)
       share_adjuster_factories.append(p_f)
     return share_adjuster_factories
+
+  @property
+  def blueprints(self):
+    return list(itertools.chain(*[s.blueprints for s in self._proxy_servers]))
 
   def signal_update(self):
     if not self._signal_update_fn:

--- a/tellapart/aurproxy/command.py
+++ b/tellapart/aurproxy/command.py
@@ -49,8 +49,15 @@ _DEFAULT_MIRROR_PORTS = None
 _DEFAULT_MIRROR_SOURCE = None
 _DEFAULT_REGISTRATION_CLASS = None
 _DEFAULT_REGISTRATION_KWARGS = []
+_DEFAULT_REPLAY_MAX_UPDATE_FREQUENCY = _DEFAULT_MIRROR_MAX_UPDATE_FREQUENCY
+
 _DEFAULT_UPDATE_PERIOD = 2
 _DEFAULT_WEIGHT_ADJUSTMENT_DELAY_SEC = 180
+
+_MIRROR_COMMAND_TEMPLATE_PATH = './tellapart/aurproxy/templates/gor' \
+                                '/mirror.sh.template'
+_REPLAY_COMMAND_TEMPLATE_PATH = './tellapart/aurproxy/templates/gor' \
+                                '/replay.sh.template'
 
 @commandr.command
 def run(management_port,
@@ -123,7 +130,8 @@ def run(management_port,
     mirror_updater = load_mirror_updater(mirror_source,
                                          mirror_ports,
                                          mirror_max_qps,
-                                         mirror_max_update_frequency)
+                                         mirror_max_update_frequency,
+                                         _MIRROR_COMMAND_TEMPLATE_PATH)
 
   if setup:
     proxy_updater.set_up()
@@ -133,13 +141,7 @@ def run(management_port,
     # Set up metrics
     set_root_prefix('aurproxy')
     if metric_publisher_class:
-      try:
-        publisher = load_cli_plugin(metric_publisher_class,
-                                    metric_publisher_arg)
-        add_publisher(publisher)
-      except Exception:
-        logger.exception('Metrics failure.')
-        raise
+      _setup_metrics(metric_publisher_class, metric_publisher_arg)
 
     # Set up registration
     if registration_class:
@@ -151,18 +153,62 @@ def run(management_port,
         logger.exception('Registration failure.')
         raise
 
-    # Start the updaters.
+    # Start the updaters and extract blueprints
     proxy_updater.start(weight_adjustment_delay_seconds)
+    blueprints = proxy_updater.blueprints
     if mirror_updater:
       mirror_updater.start()
+      blueprints += mirror_updater.blueprints
 
-    # Set up management application
-    app = Flask(__name__)
-    app.register_blueprint(lifecycle_blueprint)
-    if sentry_dsn:
-      app = setup_sentry_wsgi(app, sentry_dsn)
-    http_server = WSGIServer(('0.0.0.0', int(management_port)), app)
-    http_server.serve_forever()
+    _start_web(management_port, sentry_dsn, blueprints)
+
+@commandr.command
+def run_replay(management_port,
+               replay_port,
+               replay_source,
+               replay_max_qps,
+               replay_max_update_frequency=_DEFAULT_REPLAY_MAX_UPDATE_FREQUENCY,
+               metric_publisher_class=_DEFAULT_METRIC_PUBLISHER_CLASS,
+               metric_publisher_arg=_DEFAULT_METRIC_PUBLISHER_KWARGS,
+               sentry_dsn=None,
+               setup=False):
+  """Run the Aurproxy traffic replay server manager.
+
+  Args:
+    management_port - int - port for the manager application to listen on for
+      Aurora lifecycle queries and events (/health, /quitquit, etc.).
+    replay_port - int - port on which the replay server to listen on for a
+      mirrored traffic stream.
+    replay_source - JSON string - Source configuration to which gor replay
+      server will send traffic.
+    replay_max_qps - maximum QPS to replay to listeners.
+    replay_max_update_frequency - Max QPS to replay to source endpoints.
+    metric_publisher_class - str - Python class path for metrics publisher
+      class.
+    metric_publisher_arg - list(str) - List of equal-sign-delimited string
+      kwarg pairs.
+      Example:
+        ["source=cluster.role.environment.job"]
+    sentry_dsn - str - Sentry DSN for error logging.
+    setup - bool - When run in setup mode, aurproxy will render a configuration
+      for the replay server once and then exit. Run aurproxy once in setup mode
+      to set up the replay server, then start aurproxy and the replay server
+      together.
+  """
+  source_dict = json.loads(replay_source)
+  source = load_klass_plugin(source_dict, klass_field_name='source_class')
+  mirror_updater = load_mirror_updater(source,
+                                       replay_port,
+                                       replay_max_qps,
+                                       replay_max_update_frequency,
+                                       _REPLAY_COMMAND_TEMPLATE_PATH)
+  if setup:
+    mirror_updater.update(kill_running=False)
+  else:
+    if metric_publisher_class:
+      _setup_metrics(metric_publisher_class, metric_publisher_arg)
+    mirror_updater.start()
+    _start_web(management_port, sentry_dsn, mirror_updater.blueprints)
 
 @commandr.command
 def synchronize(registration_source,
@@ -207,6 +253,43 @@ def synchronize(registration_source,
                                registration_arg,
                                extra_kwargs=extra_kwargs)
   registerer.synchronize(write)
+
+def _setup_metrics(metric_publisher_class, metric_publisher_args):
+  """
+  Sets up a metrics publisher based on command line args.
+
+  Args:
+    metric_publisher_class
+    metric_publisher_args
+  """
+  try:
+    publisher = load_cli_plugin(metric_publisher_class,
+                                metric_publisher_args)
+    add_publisher(publisher)
+  except Exception:
+    logger.exception('Metrics failure.')
+    raise
+
+def _start_web(port, sentry_dsn=None, blueprints=None):
+  """
+  Starts a Flask app with optional error logging and blueprint registration.
+
+  Args:
+    port - str/int - port on which management application should listen for
+      HTTP traffic.
+    sentry_dsn - str - Sentry DSN for error logging.
+    blueprints - list(flask.Blueprint)- blueprints to register.
+  """
+  # Set up management application
+  app = Flask(__name__)
+  app.register_blueprint(lifecycle_blueprint)
+  if blueprints:
+    for blueprint in blueprints:
+      app.register_blueprint(blueprint)
+  if sentry_dsn:
+    app = setup_sentry_wsgi(app, sentry_dsn)
+  http_server = WSGIServer(('0.0.0.0', int(port)), app)
+  http_server.serve_forever()
 
 if __name__ == '__main__':
   commandr.Run()

--- a/tellapart/aurproxy/command.py
+++ b/tellapart/aurproxy/command.py
@@ -58,6 +58,7 @@ _MIRROR_COMMAND_TEMPLATE_PATH = './tellapart/aurproxy/templates/gor' \
                                 '/mirror.sh.template'
 _REPLAY_COMMAND_TEMPLATE_PATH = './tellapart/aurproxy/templates/gor' \
                                 '/replay.sh.template'
+_MIRROR_PID_PATH = '/tmp/mirror_pid'
 
 @commandr.command
 def run(management_port,
@@ -74,6 +75,7 @@ def run(management_port,
         mirror_ports=_DEFAULT_MIRROR_PORTS,
         mirror_max_qps=_DEFAULT_MIRROR_MAX_QPS,
         mirror_max_update_frequency=_DEFAULT_MIRROR_MAX_UPDATE_FREQUENCY,
+        mirror_pid_path=_MIRROR_PID_PATH,
         sentry_dsn=None,
         setup=False):
   """Run the Aurproxy load balancer manager.
@@ -102,7 +104,7 @@ def run(management_port,
         ["source=cluster.role.environment.job"]
     mirror_source - JSON String - Source configuration for gor repeater to
       which http traffic should be mirrored.
-    mirror_ports - Comma seperated integer string - Local ports to mirror.
+    mirror_ports - Comma separated integer string - Local ports to mirror.
       Example: "8080,8081"
     mirror_max_qps - Max QPS to mirror to gor repeater.
     mirror_max_update_frequency - integer - number of seconds between updates
@@ -131,7 +133,8 @@ def run(management_port,
                                          mirror_ports,
                                          mirror_max_qps,
                                          mirror_max_update_frequency,
-                                         _MIRROR_COMMAND_TEMPLATE_PATH)
+                                         _MIRROR_COMMAND_TEMPLATE_PATH,
+                                         mirror_pid_path)
 
   if setup:
     proxy_updater.set_up()
@@ -168,6 +171,7 @@ def run_replay(management_port,
                replay_source,
                replay_max_qps,
                replay_max_update_frequency=_DEFAULT_REPLAY_MAX_UPDATE_FREQUENCY,
+               replay_pid_path=_MIRROR_PID_PATH,
                metric_publisher_class=_DEFAULT_METRIC_PUBLISHER_CLASS,
                metric_publisher_arg=_DEFAULT_METRIC_PUBLISHER_KWARGS,
                sentry_dsn=None,
@@ -201,7 +205,8 @@ def run_replay(management_port,
                                        replay_port,
                                        replay_max_qps,
                                        replay_max_update_frequency,
-                                       _REPLAY_COMMAND_TEMPLATE_PATH)
+                                       _REPLAY_COMMAND_TEMPLATE_PATH,
+                                       replay_pid_path)
   if setup:
     mirror_updater.update(kill_running=False)
   else:

--- a/tellapart/aurproxy/config/endpoint.py
+++ b/tellapart/aurproxy/config/endpoint.py
@@ -15,10 +15,10 @@
 import hashlib
 
 class EndpointBase(object):
-  def __init__(self, host, port, port_map=None):
+  def __init__(self, host, port, context=None):
     self._host = host
     self._port = port
-    self._port_map = port_map or {}
+    self._context = context or {}
 
   @property
   def host(self):
@@ -29,12 +29,13 @@ class EndpointBase(object):
     return self._port
 
   @property
-  def port_map(self):
-    return self._port_map
+  def context(self):
+    return self._context
+
 
 class AuditableEndpointBase(EndpointBase):
-  def __init__(self, host, port, audit, port_map=None):
-    super(AuditableEndpointBase, self).__init__(host, port, port_map)
+  def __init__(self, host, port, audit, context=None):
+    super(AuditableEndpointBase, self).__init__(host, port, context)
     self._audit = audit
 
   @property
@@ -42,8 +43,8 @@ class AuditableEndpointBase(EndpointBase):
     return self._audit
 
 class ProxyEndpoint(AuditableEndpointBase):
-  def __init__(self, host, port, audit, weight, port_map=None):
-    super(ProxyEndpoint, self).__init__(host, port, audit, port_map)
+  def __init__(self, host, port, audit, weight, context=None):
+    super(ProxyEndpoint, self).__init__(host, port, audit, context)
     self._weight = weight
 
   @property
@@ -51,8 +52,8 @@ class ProxyEndpoint(AuditableEndpointBase):
     return self._weight
 
 class ShareEndpoint(AuditableEndpointBase):
-  def __init__(self, host, port, share, audit, port_map=None):
-    super(ShareEndpoint, self).__init__(host, port, audit, port_map)
+  def __init__(self, host, port, share, audit, context=None):
+    super(ShareEndpoint, self).__init__(host, port, audit, context)
     self._share = share
 
   @property

--- a/tellapart/aurproxy/config/route.py
+++ b/tellapart/aurproxy/config/route.py
@@ -20,6 +20,10 @@ class ProxyRoute(object):
     self._source_group_manager = source_group_manager
 
   @property
+  def blueprints(self):
+    return self._source_group_manager.blueprints
+
+  @property
   def locations(self):
     return self._locations
 

--- a/tellapart/aurproxy/config/server.py
+++ b/tellapart/aurproxy/config/server.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
+
 from tellapart.aurproxy.util import slugify
 
 class ProxyServer(object):
@@ -32,3 +34,7 @@ class ProxyServer(object):
     if ports_part:
       s = '{0}{1}__'.format(s, ports_part)
     return s
+
+  @property
+  def blueprints(self):
+    return list(itertools.chain(*[r.blueprints for r in self.routes]))

--- a/tellapart/aurproxy/mirror.py
+++ b/tellapart/aurproxy/mirror.py
@@ -1,0 +1,298 @@
+# Copyright 2015 TellApart, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from gevent import spawn_later
+from jinja2 import Template
+import json
+import os
+import psutil
+
+from tellapart.aurproxy.exception import AurProxyConfigException
+from tellapart.aurproxy.util import (
+  get_logger,
+  load_klass_plugin)
+
+logger = get_logger(__name__)
+
+# Fallback for use when no valid gor command line possible.
+_FALLBACK_MSG = 'No mirror source endpoints found.'
+_FALLBACK_COMMAND = 'python -c ' \
+                    '"exec(\\"from gevent import sleep\\n' \
+                    'while True:' \
+                    ' print \'{0}\';' \
+                    ' sleep(10)\\")"'.format(_FALLBACK_MSG)
+_GOR_PATH = '/opt/go/bin/gor'
+_MIRROR_COMMAND_PATH = '/etc/aurproxy/gor/mirror.sh'
+_MIRROR_COMMAND_TEMPLATE_PATH = './tellapart/aurproxy/templates' \
+                                '/gor/mirror.sh.template'
+
+def load_mirror_updater(source_config, ports, max_qps, max_update_frequency):
+  """
+  Load a MirrorUpdater.
+
+  Args:
+    source_config - JSON string - Source configuration whose endpoints describe
+      gor repeaters.
+    ports - string of comma seperated integers- Local ports to mirror.
+      Example: "8080,8081"
+    max_qps - integer - Max QPS to mirror to gor repeater.
+    max_update_frequency - integer - number of seconds between updates of
+      mirror configuration.
+
+  Returns:
+    A MirrorUpdater instance.
+  """
+  if not source_config:
+    raise AurProxyConfigException('source_config required!')
+  if not ports:
+    raise AurProxyConfigException('ports required!')
+  if not max_qps:
+    raise AurProxyConfigException('max_qps required!')
+  ports = [ int(p) for p in ports.split(',') ]
+  source_dict = json.loads(source_config)
+  source = load_klass_plugin(source_dict,
+                             klass_field_name='source_class')
+  return MirrorUpdater(source, ports, max_qps, max_update_frequency)
+
+class MirrorUpdater(object):
+  def __init__(self, source, ports, max_qps, max_update_frequency):
+    """
+    Manages updating the managed traffic mirroring process (gor).
+
+    source - aurproxy.source.ProxySource - Source whose endpoints describe
+      gor repeaters.
+    ports - list(int) - Local ports to mirror.
+      Example: [8080, 8081]
+    max_qps - integer - Max QPS to mirror to gor repeater.
+    max_update_frequency - integer - number of seconds between updates of
+      mirror configuration.
+    """
+    source.register_on_add(self._on_add)
+    source.register_on_remove(self._on_remove)
+    self._source = source
+    self._ports = ports
+    self._max_qps = max_qps
+    self._max_update_frequency = max_update_frequency
+    self._gor_path = _GOR_PATH
+    self._template_path = _MIRROR_COMMAND_TEMPLATE_PATH
+    self._command_path = _MIRROR_COMMAND_PATH
+    self._needs_update = True
+    self._updating = False
+
+  def set_up(self):
+    """
+    One-off way to generate mirroring process configuration (command).
+    """
+    self._source.start()
+    self.update(kill_running=False)
+
+  def start(self):
+    """
+    Start managing a mirroring process configuration (command).
+
+    Long running.
+    """
+    self._source.start()
+    spawn_later(self._max_update_frequency, self.update)
+
+  def _on_add(self, source, endpoint):
+    """
+    Callback when mirror endpoint is added to source.
+
+    Args:
+      source - aurproxy.source.ProxySource - Unused.
+      endpoint - aurproxy.config.endpoint.SourceEndpoint - Unused.
+
+    Returns:
+      Nothing
+    """
+    self._on_update()
+
+  def _on_remove(self, source, endpoint):
+    """
+    Callback when mirror endpoint is removed from source.
+
+    Args:
+      source - aurproxy.source.ProxySource - Unused.
+      endpoint - aurproxy.config.endpoint.SourceEndpoint - Unused.
+
+    Returns:
+      Nothing
+    """
+    self._on_update()
+
+  def _on_update(self):
+    """
+    Signal that an update of mirroring process configuration is required.
+    """
+    self._needs_update = True
+
+  def _should_update(self):
+    """
+    Determines whether an update can be applied.
+    """
+    return self._needs_update and not self._updating
+
+  def update(self, kill_running=True):
+    """
+    Update the configuration of the traffic mirroring process (gor).
+
+    Args:
+      kill_running - boolean - whether to kill running mirroring processes.
+
+    Returns:
+      Nothing
+    """
+    try:
+      if self._should_update():
+        self._needs_update = False
+        self._updating = True
+        logger.info('Updating traffic mirror configuration.')
+
+        command = self._generate_command()
+        success = self._update(command, self._command_path, kill_running)
+        if not success:
+          logger.info('Failed to update! Rescheduling.')
+          self._needs_update = True
+    except Exception:
+      self._needs_update = True
+      logger.exception('Attempt to update traffic mirror configuration'
+                       ' failed.')
+    finally:
+      self._updating = False
+      spawn_later(self._max_update_frequency, self.update)
+
+  def _generate_command(self):
+    """
+    Create command for injection into dynamic launch script.
+
+    Returns:
+      String command.
+    """
+    if not self._source.endpoints:
+      # Aurora is going to keep the replay process running whether or not we
+      # have the endpoints needed to construct a valid gor command. If we
+      # don't, drop in a placeholder.
+      command = _FALLBACK_COMMAND
+    else:
+      context = self._generate_context()
+      command = self._render(self._template_path, context)
+    return command
+
+  def _generate_context(self):
+    """
+    Build context necessary to render gor command.
+
+    Returns:
+      Context dictionary.
+    """
+    context = {}
+    context['gor_path'] = self._gor_path
+    context['ports'] = self._ports
+    context['endpoints'] = self._source.endpoints
+    context['max_qps'] = self._max_qps
+    return context
+
+  def _render(self, template_path, context):
+    """
+    Render gor command.
+
+    Args:
+      template_path - str - path to gor command template.
+      context - dict - parameters to gor command template.
+
+    Returns:
+      Rendered gor command.
+    """
+    with open(template_path) as t:
+      template = Template(t.read())
+    return template.render(**context)
+
+  def _update(self, command, command_path, kill_running):
+    """
+    Update mirroring process dynamic launch script.
+
+    Args:
+      command - str - traffic mirroring process command.
+      command_path - path to process mirroring dynamic launch script.
+      kill_running - boolean - whether to kill running mirroring processes.
+
+    Returns:
+      Boolean indicating whether update was successful.
+    """
+    updated = self._update_command(command, command_path)
+    success = False
+    if updated and kill_running:
+      # Currently no graceful restart mechanism in gor
+      # Depend on Aurora to start gor back up
+      success = self._kill_running()
+    return updated and success
+
+  def _update_command(self, command, command_path):
+    """
+    Apply update of dynamic launch script.
+
+    Args:
+      command - str - traffic mirroring process command.
+      command_path - path to process mirroring dynamic launch script.
+
+    Returns:
+      Boolean indicating whether update was applied.
+    """
+    updated = False
+    # Don't rewrite it if nothing has changed.
+    if os.path.isfile(command_path):
+      with open(command_path) as cp:
+        if cp.read() == command:
+          logger.info('Mirror command is unchanged.')
+          updated = True
+          return updated
+
+    logger.info('Writing new mirror command.')
+    logger.info('Command: {0}'.format(command))
+    try:
+      with os.fdopen(os.open(command_path,
+                             os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                             0755), 'w') as command_handle:
+        command_handle.write(command)
+        updated = True
+    except Exception:
+      logger.exception('Attempt to update mirror command failed!')
+    return updated
+
+  def _kill_running(self):
+    """
+    Kill running traffic mirror and fallback processes.
+
+    Returns:
+      Whether successful in killing all traffic mirror and fallback processes.
+    """
+    logger.info('Looking for existing traffic mirror processes.')
+    success = True
+    killed_any = False
+    try:
+      for proc in psutil.process_iter():
+        cmd_line = ' '.join(proc.cmdline())
+        if self._gor_path in cmd_line \
+          or _FALLBACK_MSG in cmd_line:
+          msg = 'Killing traffic mirror process: {0}'.format(cmd_line)
+          logger.info(msg)
+          proc.kill()
+          killed_any = True
+    except Exception:
+      logger.exception('Attempt to kill traffic mirror processes failed!')
+      success = False
+    if not killed_any:
+      logger.info('Did not kill any traffic mirror processes.')
+    return success

--- a/tellapart/aurproxy/proxy.py
+++ b/tellapart/aurproxy/proxy.py
@@ -57,6 +57,13 @@ class ProxyUpdater(object):
         and not self._updating \
         and not time_since_last < timedelta(seconds=self._max_update_frequency)
 
+  @property
+  def blueprints(self):
+    """
+    Flask blueprints describing managed APIs.
+    """
+    return self._backend.blueprints
+
   def set_up(self):
     self._start_discovery(weight_adjustment_start=None)
     self._update(restart_proxy=False)

--- a/tellapart/aurproxy/share/adjusters/health.py
+++ b/tellapart/aurproxy/share/adjusters/health.py
@@ -152,7 +152,7 @@ class HttpHealthCheckShareAdjuster(ShareAdjuster):
     """
     uri_template = 'http://{0}:{1}{2}'
     if self._port_name:
-      port = self._endpoint.port_map[self._port_name]
+      port = self._endpoint.context['port_map'][self._port_name]
     else:
       port = self._endpoint.port
     return uri_template.format(self._endpoint.host,

--- a/tellapart/aurproxy/source/__init__.py
+++ b/tellapart/aurproxy/source/__init__.py
@@ -14,5 +14,6 @@
 
 from .manager import SourceGroupManager
 from .source import ProxySource
+from .sources.api import ApiSource
 from .sources.aurora import AuroraProxySource
 from .sources.static import StaticProxySource

--- a/tellapart/aurproxy/source/manager.py
+++ b/tellapart/aurproxy/source/manager.py
@@ -112,6 +112,10 @@ class SourceGroupManager(object):
       logger.exception('Error removing endpoint.')
 
   @property
+  def blueprints(self):
+    return [s.blueprint for s in self._sources if s.blueprint]
+
+  @property
   def endpoints(self):
     """
     A list of ProxyEndpoints for sources managed by this SourceGroupManager.

--- a/tellapart/aurproxy/source/source.py
+++ b/tellapart/aurproxy/source/source.py
@@ -14,6 +14,7 @@
 
 from abc import (
   ABCMeta,
+  abstractmethod,
   abstractproperty)
 
 from tellapart.aurproxy.util import get_logger
@@ -37,12 +38,20 @@ class ProxySource(object):
     return self._endpoints
 
   @abstractproperty
-  def slug(self):
+  def blueprint(self):
     pass
 
   @abstractproperty
+  def slug(self):
+    pass
+
+  @abstractmethod
   def start(self):
     pass
+
+  def stop(self):
+    for endpoint in self._endpoints:
+      self.remove(endpoint)
 
   def add(self, endpoint):
     if endpoint not in self._endpoints:

--- a/tellapart/aurproxy/source/sources/api.py
+++ b/tellapart/aurproxy/source/sources/api.py
@@ -1,0 +1,336 @@
+# Copyright 2015 TellApart, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__copyright__ = 'Copyright (C) 2015 TellApart, Inc. All Rights Reserved.'
+
+
+from collections import defaultdict
+from datetime import (
+  datetime,
+  timedelta)
+import dateutil.parser
+from flask import (
+  Blueprint,
+  request)
+from flask.ext.restful import (
+  abort,
+  Api,
+  Resource)
+from gevent import spawn_later
+from gevent.event import Event
+
+from tellapart.aurproxy.exception import AurProxyConfigException
+from tellapart.aurproxy.source import ProxySource
+from tellapart.aurproxy.util import (
+  get_logger,
+  load_klass_plugin)
+
+logger = get_logger(__name__)
+
+_DEFAULT_SOURCE_WHITELIST = ['tellapart.aurproxy.source.StaticProxySource',
+                             'tellapart.aurproxy.source.AuroraProxySource']
+
+class ApiSource(ProxySource):
+  """Source that exposes an HTTP API that supports the dynamic addition and
+  removal of other sources.
+  """
+
+  def __init__(self,
+               name,
+               source_whitelist=_DEFAULT_SOURCE_WHITELIST,
+               signal_update_fn=None,
+               share_updater_factories=None):
+    """
+    Args:
+      name - Required str name of this API source. Should be unique per
+        aurproxy task instance.
+      source_whitelist - Optional list(str) of source class paths that are
+        allowed to be instantiated.
+      signal_update_fn - Optional callback fn - used to signal need to update.
+      share_updater_factories - Optional list of ShareAdjuster factories.
+    """
+    super(ApiSource, self).__init__(signal_update_fn, share_updater_factories)
+    if not name:
+      raise AurProxyConfigException(name)
+    self._name = name
+    self._source_whitelist = source_whitelist
+    self._source_map = defaultdict(dict)
+    self._blueprint = self._build_blueprint(name)
+
+  @property
+  def slug(self):
+    """Configuration and URL slug for this source instance."""
+    return self._name
+
+  def start(self):
+    """Start maintaining endpoint list."""
+    pass
+
+  def stop(self):
+    """Stop maintaining endpoint list."""
+    for source_name in self._all_managed_source_names():
+      self._delete_managed_source(source_name)
+
+  @property
+  def blueprint(self):
+    """Flask blueprint for HTTP API."""
+    return self._blueprint
+
+  def _build_blueprint(self, name):
+    """
+    Build a flask blueprint that exposes an HTTP API with endpoints for the
+    addition and removal of sources.
+
+    Args:
+        name - Required str name to be used in API routes.
+    """
+    blueprint = Blueprint(name, __name__)
+    api = Api(blueprint)
+    root = self
+
+    class DynamicSource(Resource):
+
+      def get(self, source_name):
+        managed_source = root._get_managed_source(source_name)
+        if not managed_source:
+          root._abort(source_name)
+        else:
+          return managed_source.configuration
+
+      def delete(self, source_name):
+        if not root._get_managed_source(source_name):
+          root._abort(source_name)
+        else:
+          root._delete_managed_source(source_name)
+        return '', 204
+
+      def put(self, source_name):
+        source_config = request.json.get('source')
+        expiration = self._parse_expiration(request.json.get('expiration',
+                                                             None))
+        if not root._get_managed_source(source_name):
+          root._add_managed_source(source_name, source_config, expiration)
+          response_code = 201
+        else:
+          root._delete_managed_source(source_name)
+          root._add_managed_source(source_name, source_config, expiration)
+          response_code = 200
+
+        return source_config, response_code
+
+      def _parse_expiration(self, expiration):
+        expiration_parsed = None
+        if expiration:
+          try:
+            expiration_parsed = dateutil.parser.parse(expiration)
+          except:
+            msg = 'Attempt to parse expiration failed!'
+            logger.exception(msg)
+            raise abort(400, message=msg)
+          if datetime.now() + timedelta(minutes=1) > expiration_parsed:
+            msg = 'Expiration must occur at least 1 minute in the future!'
+            logger.info(msg)
+            raise abort(400, message=msg)
+        return expiration_parsed
+
+    class DynamicSourceList(Resource):
+      def get(self):
+        return root._source_map.keys()
+
+    # List sources
+    api.add_resource(DynamicSourceList,
+                           '/api/source/{0}/sources'.format(name))
+
+    # Get detail for a source
+    api.add_resource(DynamicSource,
+                     '/api/source/{0}/source/<source_name>/'.format(name))
+
+    return blueprint
+
+  def _abort(self, name):
+    """
+    Abort an http request with a 404.
+
+    Args:
+        name - Required source name str to be used in error message.
+    """
+    message = "Source {0} doesn't exist".format(name)
+    abort(404, message=message)
+
+  @property
+  def endpoints(self):
+    """
+    List of SourceEndpoints for sources managed by this ApiSource instance.
+    """
+    eps = set()
+    for source_name in self._all_managed_source_names():
+      managed_source = self._get_managed_source(source_name)
+      eps = eps | set(managed_source.source.endpoints)
+    return eps
+
+  def __on_source_add(self, source, endpoint):
+    """When adding a managed source."""
+    self._execute_callbacks(callbacks=self._on_add_fns,
+                            source=self,
+                            endpoint=endpoint)
+    if self._signal_update_fn:
+      self._signal_update_fn()
+
+  def __on_source_remove(self, source, endpoint):
+    """When removing a managed source."""
+    self._execute_callbacks(callbacks=self._on_remove_fns,
+                            source=self,
+                            endpoint=endpoint)
+    if self._signal_update_fn:
+      self._signal_update_fn()
+
+  def _load_source(self, source_config):
+    """
+    Loads a source from a source configuration string.
+
+    Args:
+      source_config - JSON string source configuration.
+
+    Returns:
+      tellapart.aurproxy.source.ProxySource instance.
+    """
+    source_class = source_config.get('source_class', None)
+    if not source_class or source_class not in self._source_whitelist:
+      message = 'Invalid source_class \'{0}\''.format(source_class)
+      raise abort(403, message=message)
+
+    source = load_klass_plugin(source_config,
+                               klass_field_name='source_class')
+    source.register_on_add(self.__on_source_add)
+    source.register_on_remove(self.__on_source_remove)
+    return source
+
+  def _all_managed_source_names(self):
+    """Names of all managed sources."""
+    return self._source_map.keys()
+
+  def _add_managed_source(self, source_name, source_config, expiration_time):
+    """
+    Adds a managed source.
+
+    Args:
+      source_name - name of managed source.
+      source_config - JSON string source configuration for managed source.
+      expiration_time - datetime at which to expire managed source.
+    """
+    logger.info('Adding Managed Source: {0}/{1}'.format(self._name,
+                                                        source_name))
+    source = self._load_source(source_config)
+    exp = None
+    if expiration_time:
+      exp = self._build_expiration(source_name, expiration_time)
+    managed_source = ManagedSource(source_name, source, source_config, exp)
+    self._source_map[source_name] = managed_source
+    managed_source.source.start()
+    if managed_source.expiration:
+      managed_source.expiration.start()
+
+  def _delete_managed_source(self, source_name):
+    """
+    Deletes a managed source.
+
+    Args:
+      source_name - name of managed source to delete.
+    """
+    logger.info('Deleting Managed Source: {0}/{1}'.format(self._name,
+                                                          source_name))
+    managed_source = self._source_map.pop(source_name)
+    if managed_source.expiration:
+      managed_source.expiration.cancel()
+    managed_source.source.stop()
+
+  def _get_managed_source(self, source_name):
+    """
+    Retrieves a managed source.
+
+    Args:
+      source_name - name of managed source to retrieve.
+
+    Returns:
+      ManagedSource or None if not found.
+    """
+    return self._source_map.get(source_name, None)
+
+  def _build_expiration(self, source_name, expiration_time):
+    """
+    Builds an Expiration object with bookkeeping callback for source deletion.
+
+    Args:
+      source_name - name of managed source to expire.
+      expiration_time - datetime at which to expire managed source.
+
+    Returns:
+      Unstarted Expiration
+    """
+    def __cb():
+      logger.info('Expiring Managed Source: {0}'.format(source_name))
+      self._delete_managed_source(source_name)
+    return Expiration(expiration_time, __cb)
+
+class ManagedSource(object):
+  """
+  Collection of information about a source managed by ApiSource.
+  """
+  def __init__(self, name, source, source_config, expiration):
+    """
+    Args:
+      name - name of ManagedSource.
+      source - tellapart.aurproxy.source.ProxySource.
+      source_config - JSON String config of source.
+      expiration - Expiration object managing expiration lifecycle.
+    """
+    self.name = name
+    self.source = source
+    self.configuration = source_config
+    self.expiration = expiration
+
+class Expiration(object):
+  """
+  Manages the lifecycle of another object.
+  """
+  def __init__(self, expiration_time, callback):
+    """
+    Args:
+      expiration_time - datetime at which to expire managed source.
+      callback - function to call when expiration time has been reached.
+    """
+    self._expiration_time = expiration_time
+    self._callback = callback
+    self._cancel_event = Event()
+
+  def start(self):
+    """
+    Start expiration countdown.
+    """
+    seconds = (self._expiration_time - datetime.now()).total_seconds()
+    spawn_later(seconds, self._cb)
+
+  def cancel(self):
+    """
+    Cancel expiration countdown.
+    """
+    self._cancel_event.set()
+
+  def _cb(self):
+    """
+    Execute original callback.
+    """
+    if not self._cancel_event.is_set():
+      self.cancel()
+      self._callback()

--- a/tellapart/aurproxy/source/sources/aurora.py
+++ b/tellapart/aurproxy/source/sources/aurora.py
@@ -56,7 +56,11 @@ class AuroraProxySource(ProxySource):
     self._zk_servers = zk_servers
     self._endpoint = endpoint
     self._announcer_serverset_path = announcer_serverset_path
-    self._server_set = None
+    self._server_set = []
+
+  @property
+  def blueprint(self):
+    return None
 
   @property
   def slug(self):
@@ -68,6 +72,9 @@ class AuroraProxySource(ProxySource):
       _ZK_MAP[self._zk_servers] = self._get_kazoo_client()
     self._server_set = self._get_server_set()
     [ self.add(self._get_endpoint(s)) for s in self._server_set ]
+
+  def stop(self):
+    [ self.remove(self._get_endpoint(s)) for s in self._server_set ]
 
   @property
   def _zk(self):
@@ -83,7 +90,7 @@ class AuroraProxySource(ProxySource):
       port_map[k] = v.port
     return SourceEndpoint(host=ep.host,
                           port=ep.port,
-                          port_map=port_map)
+                          context={'port_map': port_map})
 
   def _get_kazoo_client(self):
     kc = KazooClient(

--- a/tellapart/aurproxy/source/sources/static.py
+++ b/tellapart/aurproxy/source/sources/static.py
@@ -27,6 +27,7 @@ class StaticProxySource(ProxySource):
     self._name = kwargs.get('name')
     self._host = kwargs.get('host')
     self._port = kwargs.get('port')
+    self._endpoint = SourceEndpoint(self._host, self._port)
     err_fmt = '"{0}" required on StaticProxySource'
     if not self._name:
       raise AurProxyConfigException(err_fmt.format('name'))
@@ -36,10 +37,17 @@ class StaticProxySource(ProxySource):
       raise AurProxyConfigException(err_fmt.format('port'))
 
   @property
+  def blueprint(self):
+    return None
+
+  @property
   def slug(self):
     return '{0}__{1}__{2}'.format(self._name,
                                   self._host,
                                   self._port)
 
   def start(self):
-    self.add(SourceEndpoint(self._host, self._port))
+    self.add(self._endpoint)
+
+  def stop(self):
+    self.remove(self._endpoint)

--- a/tellapart/aurproxytest/mirror.py
+++ b/tellapart/aurproxytest/mirror.py
@@ -39,11 +39,14 @@ class MirrorUpdaterTests(unittest.TestCase):
       "port": 80
     })
 
+    template_path = '../templates/gor/mirror.sh.template'
+
     # Load up a mirror updater
-    mirror_updater = load_mirror_updater(source_config=static_source_config,
+    mirror_updater = load_mirror_updater(source=static_source_config,
                                          ports='8080,8081',
                                          max_qps=100,
-                                         max_update_frequency=15)
+                                         max_update_frequency=15,
+                                         command_template_path=template_path)
 
     # Patch in the dummy update function
     funcType = type(MirrorUpdater.update)

--- a/tellapart/aurproxytest/mirror.py
+++ b/tellapart/aurproxytest/mirror.py
@@ -1,0 +1,88 @@
+# Copyright 2015 TellApart, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import unittest
+
+from tellapart.aurproxy.mirror import (
+  _FALLBACK_MSG,
+  load_mirror_updater,
+  MirrorUpdater)
+from tellapart.aurproxy.config import SourceEndpoint
+
+
+def dummy_update(self, kill_running=True):
+  self._needs_update = False
+
+class MirrorUpdaterTests(unittest.TestCase):
+  def test_mirror_updater(self):
+    '''
+    Tests MirrorUpdater update flag status and command contents when creating,
+    adding, removing, and eliminating endpoints.
+    '''
+    static_source_config = json.dumps({
+      "source_class": "tellapart.aurproxy.source.StaticProxySource",
+      "host": "127.0.0.1",
+      "name": "base",
+      "port": 80
+    })
+
+    # Load up a mirror updater
+    mirror_updater = load_mirror_updater(source_config=static_source_config,
+                                         ports='8080,8081',
+                                         max_qps=100,
+                                         max_update_frequency=15)
+
+    # Patch in the dummy update function
+    funcType = type(MirrorUpdater.update)
+    mirror_updater.update = funcType(dummy_update,
+                                     mirror_updater,
+                                     MirrorUpdater)
+
+    # Correct the template path for test time
+    template_path = os.path.join(os.path.dirname(__file__),
+                                 '../../templates/gor/mirror.sh.template')
+    mirror_updater._template_path = template_path
+
+    # Check that update signals flow correctly through to command
+    # Initial setup
+    self.assertTrue(mirror_updater._should_update())
+    mirror_updater.set_up()
+    self.assertTrue('127.0.0.1:80' in mirror_updater._generate_command())
+    self.assertFalse(mirror_updater._should_update())
+
+    # Add a new endpoint
+    mirror_updater._source.add(SourceEndpoint('127.0.0.1', 81))
+    self.assertTrue(mirror_updater._should_update())
+    mirror_updater.update()
+    self.assertTrue('127.0.0.1:81' in mirror_updater._generate_command())
+    self.assertFalse(mirror_updater._should_update())
+
+    # Remove the new endpoint
+    mirror_updater._source.remove(SourceEndpoint('127.0.0.1', 81))
+    self.assertTrue(mirror_updater._should_update())
+    mirror_updater.update()
+    self.assertTrue('127.0.0.1:81' not in mirror_updater._generate_command())
+
+    # Remove the only remaining endpoint
+    mirror_updater._source.remove(SourceEndpoint('127.0.0.1', 80))
+    self.assertTrue(mirror_updater._should_update())
+    mirror_updater.update()
+    self.assertTrue('127.0.0.1:80' not in mirror_updater._generate_command())
+    self.assertTrue(_FALLBACK_MSG in mirror_updater._generate_command())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tellapart/aurproxytest/source/source.py
+++ b/tellapart/aurproxytest/source/source.py
@@ -33,6 +33,10 @@ class TstSource(ProxySource):
       self_cb(self)
 
   @property
+  def blueprint(self):
+    return None
+
+  @property
   def endpoints(self):
     return self._endpoints
 

--- a/templates/gor/mirror.sh.template
+++ b/templates/gor/mirror.sh.template
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+{{gor_path}} -output-http-stats -stats{% for port in ports %} --input-raw :{{port}}{% endfor %}{% for endpoint in endpoints %} --output-tcp "{{endpoint.host}}:{{endpoint.port}}|{{max_qps}}"{% endfor %}

--- a/templates/gor/mirror.sh.template
+++ b/templates/gor/mirror.sh.template
@@ -1,3 +1,3 @@
 #!/bin/bash
-
-{{gor_path}} -output-http-stats -stats{% for port in ports %} --input-raw :{{port}}{% endfor %}{% for endpoint in endpoints %} --output-tcp "{{endpoint.host}}:{{endpoint.port}}|{{max_qps}}"{% endfor %}
+echo $$ > {{pid_path}}
+exec {{gor_path}} -output-http-stats -stats{% for port in ports %} --input-raw :{{port}}{% endfor %}{% for endpoint in endpoints %} --output-tcp "{{endpoint.host}}:{{endpoint.port}}|{{max_qps}}"{% endfor %}

--- a/templates/gor/replay.sh.template
+++ b/templates/gor/replay.sh.template
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+{{gor_path}} -output-http-stats -stats{% for port in ports %} --input-tcp 0.0.0.0:{{port}}{% endfor %}{% for endpoint in endpoints %} --output-http "{{endpoint.host}}:{{endpoint.port}}|{{max_qps}}"{% endfor %}

--- a/templates/gor/replay.sh.template
+++ b/templates/gor/replay.sh.template
@@ -1,3 +1,3 @@
 #!/bin/bash
-
-{{gor_path}} -output-http-stats -stats{% for port in ports %} --input-tcp 0.0.0.0:{{port}}{% endfor %}{% for endpoint in endpoints %} --output-http "{{endpoint.host}}:{{endpoint.port}}|{{max_qps}}"{% endfor %}
+echo $$ > {{pid_path}}
+exec {{gor_path}} -output-http-stats -stats{% for port in ports %} --input-tcp 0.0.0.0:{{port}}{% endfor %}{% for endpoint in endpoints %} --output-http "{{endpoint.host}}:{{endpoint.port}}|{{max_qps}}"{% endfor %}


### PR DESCRIPTION
Uses gor to (optionally) replicate a specified number of queries per second over a TCP stream to one or more gor replication servers.

Also adds a replay mode in which the aurproxy management app manages only a gor worker in replay mode - meant to provide a way to fan out mirrored traffic without direct impact on the production routing layer.
