### PR TITLE
Fix missing --management-port option when starting on Aurora devcluster.

### DIFF
--- a/examples/aurproxy_hello_world.aur
+++ b/examples/aurproxy_hello_world.aur
@@ -123,5 +123,5 @@ jobs = [
                                endpoint='http')])],
                       context=ProxyContext(
                         default_server=True,
-                        location_blacklist=["/health", "/quitquitquit", "/abortabortabort"]))]).json_dumps() + '\'')
+                        location_blacklist=["/health", "/quitquitquit", "/abortabortabort"]))]).json_dumps() + '\'' + ' --management-port=31325' )
 ]


### PR DESCRIPTION
I had some trouble making the "on Aurora devcluster" instructions work until I realized that aurproxy was tripping over the missing `--management-port` option.

This patch hardcodes the `management-port` to 31325 in the example file. I'm not sure this is generally correct -- this is my first day on Aurora, and I'm not even sure what this option is doing -- but it seems to have worked to get the example running.
