### PR TITLE
Update example for the RampingShareAdjuster

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,8 @@ values (EG: "default_server": True)
                                 "share_adjusters": [
                                     {
                                         "share_adjuster_class": "aurproxy.share.adjusters.RampingShareAdjuster",
-                                        "seconds": 60,
+                                        "ramp_seconds": 60,
+                                        "ramp_delay": 10,
                                         "update_frequency": 10,
                                         "curve": "linear"
                                     },


### PR DESCRIPTION
It was actually incorrect as `seconds` should have been `ramp_seconds` and `ramp_delay` is a required option.

Just reading the docs and trying out the examples. Found that this one was wrong and fixed it.
