### PR TITLE
Fix logging of nginx errors to stderr.

### DIFF
--- a/templates/nginx/nginx.conf.template
+++ b/templates/nginx/nginx.conf.template
@@ -34,7 +34,7 @@ http {
                                      '"$upstream_addr" $msec';
 
     access_log /dev/stdout combined_forwarded_ip;
-    error_log /dev/stderr;
+    error_log stderr;
 
     gzip on;
 


### PR DESCRIPTION
Pointing it to /dev/stderr was incorrect - according to the nginx docs, you should use the "stderr" keyword to point log output to stderr.

See: http://nginx.org/en/docs/ngx_core_module.html#error_log
