### PR TITLE
Fix failing test for the mirroring functionality

### DIFF
--- a/tellapart/aurproxytest/mirror.py
+++ b/tellapart/aurproxytest/mirror.py
@@ -46,7 +46,8 @@ class MirrorUpdaterTests(unittest.TestCase):
                                          ports='8080,8081',
                                          max_qps=100,
                                          max_update_frequency=15,
-                                         command_template_path=template_path)
+                                         command_template_path=template_path,
+                                         pid_path='/tmp/gor-mirror.pid')
 
     # Patch in the dummy update function
     funcType = type(MirrorUpdater.update)


### PR DESCRIPTION
Before:

``` python
ERROR: Tests MirrorUpdater update flag status and command contents when creating,
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jschroeder/git/aurproxy/tellapart/aurproxytest/mirror.py", line 49, in test_mirror_updater
    command_template_path=template_path)
TypeError: load_mirror_updater() takes exactly 6 arguments (5 given)
```

After... nada.
