### PR TITLE
Make the healthcheck http verb configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ Sentry.
   marked as being unhealthy. (EG: 2)
 - **healthy_threshold:** Number of failed checks before an unhealthy task is
   marked as being healthy. (EG: 2)
+- **http_method:** Which http method to use for healthchecks (EG: HEAD or GET)
 
 ### Context
 Some of the configuration elements above support a "context" dictionary. This


### PR DESCRIPTION
HEAD requests use less resources, so they can be executed more frequently.

An example configuration would look like:

``` json
                            "share_adjusters": [
                                {   
                                    "healthy_threshold": 2,
                                    "interval": 3,
                                    "port_name": "http",
                                    "route": "/health",
                                    "share_adjuster_class": "tellapart.aurproxy.share.adjusters.HttpHealthCheckShareAdjuster",
                                    "timeout": 5,
                                    "unhealthy_threshold": 2,
                                    "http_method": "HEAD"
                                }   
                            ]
```

I'd like your thoughts on the best way to write some tests for this before merging it however. There are some very simple tests for the adjusters, but nothing for the healthcheck adjusters. I might have more time to try to dig into writing some tests for this in the evenings, but this certainly works from my testing.
