### PR TITLE
Use native python bits where possible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 boto==2.34.0
 commandr==1.3.2
-Fabric==1.10.0
 Flask-RESTful==0.3.1
 gevent==1.0.1
 Jinja2==2.7.3

--- a/tellapart/aurproxy/backends/backend.py
+++ b/tellapart/aurproxy/backends/backend.py
@@ -16,8 +16,10 @@ from abc import (
   ABCMeta,
   abstractmethod,
   abstractproperty)
+
 import copy
 import itertools
+import shutil
 
 from tellapart.aurproxy.config import (
   ProxyRoute,
@@ -167,6 +169,15 @@ class ProxyBackend(object):
       for server in self._proxy_servers:
         for route in server.routes:
           route.start(weight_adjustment_start)
+
+  def move_file(self, source, destination):
+    try:
+      shutil.move(source, destination)
+    except (OSError, IOError):
+      logger.exception('Failed to move {} to {}'.format(
+        source,
+        destination,
+      ))
 
   @abstractmethod
   def update(self, restart_proxy):

--- a/tellapart/aurproxy/backends/backend.py
+++ b/tellapart/aurproxy/backends/backend.py
@@ -170,15 +170,6 @@ class ProxyBackend(object):
         for route in server.routes:
           route.start(weight_adjustment_start)
 
-  def move_file(self, source, destination):
-    try:
-      shutil.move(source, destination)
-    except (OSError, IOError):
-      logger.exception('Failed to move {} to {}'.format(
-        source,
-        destination,
-      ))
-
   @abstractmethod
   def update(self, restart_proxy):
     pass

--- a/tellapart/aurproxy/backends/nginx/backend.py
+++ b/tellapart/aurproxy/backends/nginx/backend.py
@@ -21,7 +21,8 @@ from tellapart.aurproxy.backends.nginx.metrics import \
 from tellapart.aurproxy.metrics.store import increment_counter
 from tellapart.aurproxy.util import (
   get_logger,
-  run_local)
+  run_local,
+  move_file)
 
 logger = get_logger(__name__)
 
@@ -140,9 +141,9 @@ class NginxProxyBackend(ProxyBackend):
   def _backup(self, config_dest):
     if os.path.isfile(config_dest):
       backup_path = self._build_backup_path(config_dest)
-      self.move_file(config_dest, backup_path)
+      move_file(config_dest, backup_path)
 
   def _revert(self, config_dest):
     backup_path = self._build_backup_path(config_dest)
     if os.path.isfile(backup_path):
-      self.move_file(backup_path, config_dest)
+      move_file(backup_path, config_dest)

--- a/tellapart/aurproxy/backends/nginx/backend.py
+++ b/tellapart/aurproxy/backends/nginx/backend.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from jinja2 import Template
 import os
+from jinja2 import Template
 
 from tellapart.aurproxy.backends import ProxyBackend
 from tellapart.aurproxy.backends.nginx.metrics import \
@@ -55,6 +55,7 @@ class NginxProxyBackend(ProxyBackend):
                                               config,
                                               default=None,
                                               required=False)
+
     if self._stats_port:
       self._metrics_publisher = NginxProxyMetricsPublisher(self._stats_port)
     else:
@@ -139,10 +140,9 @@ class NginxProxyBackend(ProxyBackend):
   def _backup(self, config_dest):
     if os.path.isfile(config_dest):
       backup_path = self._build_backup_path(config_dest)
-      run_local('mv {0} {1}'.format(config_dest, backup_path))
+      self.move_file(config_dest, backup_path)
 
   def _revert(self, config_dest):
     backup_path = self._build_backup_path(config_dest)
     if os.path.isfile(backup_path):
-      run_local('mv {0} {1}'.format(backup_path,
-                                    config_dest))
+      self.move_file(backup_path, config_dest)

--- a/tellapart/aurproxy/util.py
+++ b/tellapart/aurproxy/util.py
@@ -32,7 +32,7 @@ from raven.middleware import Sentry
 _CLASS_PATH_TO_CLASS_CACHE = {}
 
 
-CommandResult = namedtuple('CommandResult', 'returncode', 'stdout', 'stderr')
+CommandResult = namedtuple('CommandResult', 'returncode, stdout, stderr')
 
 
 def class_from_class_path(class_path):

--- a/tellapart/aurproxy/util.py
+++ b/tellapart/aurproxy/util.py
@@ -158,6 +158,16 @@ def run_local(command, capture=False):
     )
 
 
+  def move_file(self, source, destination):
+    try:
+      shutil.move(source, destination)
+    except (OSError, IOError):
+      logger.exception('Failed to move {} to {}'.format(
+        source,
+        destination,
+      ))
+
+
 def setup_sentry(dsn=None):
   """Configures the Sentry logging handler.
 


### PR DESCRIPTION
- Use native python code for moving files instead of forking `/usr/bin/mv`
- Rewrite `aurproxy.utils.run_local()` to use `subprocess.Popen()` instead of fabric
- Totally remove fabric as it isn't necessary any longer

If you're ok with it, I'll likely change the `kill $( cat /var/run/nginx.pid )` currently in the nginx backend to use `nginx -s` instead (using the new `run_local`). That way, it will show you the actual error from nginx if/when there is a reason that prevents nginx from reloading, such as no upstreams or an error in the rendered template.

I'd also like to make the reload command configurable, but those are for future PRs.
