### PR TITLE
nginx template whitespace cleanup

### DIFF
--- a/templates/nginx/nginx.conf.template
+++ b/templates/nginx/nginx.conf.template
@@ -62,10 +62,10 @@ http {
             deny all;
         }
     }
-    {% endif %}
+    {%- endif %}
 
     {% for server in servers %}
-    {% if server.context.overflow_port %}
+    {%- if server.context.overflow_port %}
     server {
         listen {{server.context.overflow_port}} default_server;
         location /aurproxy_error.html {
@@ -77,7 +77,7 @@ http {
             return 502;
         }
     }
-    {% endif %}
+    {%- endif %}
     {% for route in server.routes %}
     upstream {{ server.slug }}{{ route.slug }} {
         least_conn;
@@ -85,13 +85,13 @@ http {
         {% endfor %}
         keepalive 512;
     }
-    {% endfor %}
+    {%- endfor %}
 
     server {
-        {% for port in server.ports %}listen {{ port }} {{'default_server' if server.context.default_server else ''}};
-        {% endfor %}
+        {% for port in server.ports %}listen {{ port }}{{' default_server' if server.context.default_server == 'True' else ''}};
+        {%- endfor %}
 
-        server_name {% for host in server.hosts %}{{ host }} {% endfor %};
+        server_name {% for host in server.hosts %}{{ host }}{% if not loop.last%} {% endif %}{% endfor %};
 
         proxy_connect_timeout  {{ server.context.proxy_connect_timeout or 60 }};
         proxy_send_timeout     {{ server.context.proxy_send_timeout or 60 }};
@@ -115,7 +115,7 @@ http {
         {% for blacklisted_location in server.context.location_blacklist %}location {{blacklisted_location}} {
           deny all;
         }
-        {% endfor %}
+        {%- endfor %}
 
         proxy_http_version 1.1;
         proxy_set_header  Host            $host;
@@ -128,8 +128,8 @@ http {
             proxy_next_upstream off;
             proxy_pass http://{{ server.slug }}{{ route.slug }};
         }
-        {% endfor %}
-        {% endfor %}
+        {%- endfor %}
+        {%- endfor %}
     }
     {% endfor %}
 }


### PR DESCRIPTION
Fix a bit of whitespace in the default nginx template. Totally trivial commit, but I'll likely expand on this a bit down the road to allow running nginx as a different user and whatnot in followup PRs.
