### PR TITLE
Connection Refused != Connection refused

### DIFF
--- a/tellapart/aurproxy/share/adjusters/health.py
+++ b/tellapart/aurproxy/share/adjusters/health.py
@@ -205,7 +205,7 @@ class HttpHealthCheckShareAdjuster(ShareAdjuster):
       if 'gaierror' in unicode(ex):
         check_result = HealthCheckResult.KNOWN_LOCAL_ERROR
         error_log_fn = logger.error
-      elif 'Connection Refused' in unicode(ex):
+      elif 'connection refused' in unicode(ex).lower():
         check_result = HealthCheckResult.KNOWN_REMOTE_ERROR
         error_log_fn = logger.error
       else:


### PR DESCRIPTION
This ensures that when the healthchecker fails due to Aurora / mesos
killing an instance, that it doesn't return a traceback.

Each failed healthcheck was returning an exception with `Connection refused` instead of `Connection Refused`, which the code already correctly accounts for.

Example:

``` python
2015-07-13 10:57:20,080 [ERROR] tellapart.aurproxy.share.adjusters.health: Exception when executing HttpHealthCheck.
Traceback (most recent call last):
  File "tellapart/aurproxy/share/adjusters/health.py", line 188, in _check
    r = getattr(requests, self._http_method)(check_uri, timeout=self._timeout)
  File "/home/jschroeder/git/aurproxy/ve/lib/python2.7/site-packages/requests/api.py", line 87, in head
    return request('head', url, **kwargs)
  File "/home/jschroeder/git/aurproxy/ve/lib/python2.7/site-packages/requests/api.py", line 49, in request
    response = session.request(method=method, url=url, **kwargs)
  File "/home/jschroeder/git/aurproxy/ve/lib/python2.7/site-packages/requests/sessions.py", line 461, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/jschroeder/git/aurproxy/ve/lib/python2.7/site-packages/requests/sessions.py", line 573, in send
    r = adapter.send(request, **kwargs)
  File "/home/jschroeder/git/aurproxy/ve/lib/python2.7/site-packages/requests/adapters.py", line 415, in send
    raise ConnectionError(err, request=request)
ConnectionError: ('Connection aborted.', error(111, 'Connection refused'))
```

If there is a case which returns `Connection Refused`, this will work for both.
