### PR TITLE
Add graceful handling for empty endpoint lists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,9 @@ Sentry.
 ### ProxyRoute
 - **locations:** Required list with one or more HTTP routes (EG: ["/"])
 - **sources:** Required list with one or more ProxySource dictionaries
+- **empty_endpoint_status_code:** Optional status code to return if there are
+  no available endpoints. Defaults to 503 (Service Unavailable) if not
+  specified.
 - **overflow_sources:** Optional list of one or more ProxySource dictionaries
 - **overflow\_threshold\_pct:** Optional threshold past which traffic will be
   sent to overflow_source.

--- a/tellapart/aurproxy/backends/backend.py
+++ b/tellapart/aurproxy/backends/backend.py
@@ -17,6 +17,7 @@ from abc import (
   abstractmethod,
   abstractproperty)
 import copy
+import httplib
 import itertools
 
 from tellapart.aurproxy.config import (
@@ -115,6 +116,11 @@ class ProxyBackend(object):
                                               route,
                                               required=False,
                                               default=[])
+    empty_endpoint_status_code = self._load_config_item(
+        'empty_endpoint_status_code',
+        route,
+        required=False,
+        default=httplib.SERVICE_UNAVAILABLE)
     proxy_overflow_sources = self._load_proxy_sources(overflow_sources)
     overflow_threshold_pct = self._load_config_item('overflow_threshold_pct',
                                                     route,
@@ -124,7 +130,8 @@ class ProxyBackend(object):
                                               overflow_threshold_pct,
                                               self._signal_update_fn,)
 
-    return ProxyRoute(locations, source_group_manager)
+    return ProxyRoute(
+        locations, empty_endpoint_status_code, source_group_manager)
 
   def _load_proxy_sources(self, sources):
     proxy_sources = []

--- a/tellapart/aurproxy/config/route.py
+++ b/tellapart/aurproxy/config/route.py
@@ -15,8 +15,10 @@
 class ProxyRoute(object):
   def __init__(self,
                locations,
+               empty_endpoint_status_code,
                source_group_manager):
     self._locations = locations
+    self._empty_endpoint_status_code = empty_endpoint_status_code
     self._source_group_manager = source_group_manager
 
   @property
@@ -30,6 +32,10 @@ class ProxyRoute(object):
   @property
   def endpoints(self):
     return self._source_group_manager.endpoints
+
+  @property
+  def empty_endpoint_status_code(self):
+    return self._empty_endpoint_status_code
 
   @property
   def slug(self):

--- a/templates/nginx/nginx.conf.template
+++ b/templates/nginx/nginx.conf.template
@@ -80,12 +80,14 @@ http {
     }
     {%- endif %}
     {% for route in server.routes %}
+    {% if route.endpoints %}
     upstream {{ server.slug }}{{ route.slug }} {
         least_conn;
         {% for endpoint in route.endpoints %}{% if not endpoint.weight %}#{% endif %}server {{ endpoint.host }}:{{ endpoint.port }} weight={{ endpoint.weight }}; # {{ endpoint.audit.render() }}
         {% endfor %}
         keepalive 512;
     }
+    {% endif %}
     {%- endfor %}
 
     server {
@@ -126,8 +128,14 @@ http {
         {% for route in server.routes %}
         {% for location in route.locations %}
         location {{location}} {
+            {% if route.endpoints %}
             proxy_next_upstream off;
             proxy_pass http://{{ server.slug }}{{ route.slug }};
+            {% else %}
+            # No endpoints found for {{ server.slug }}{{ route.slug }}
+            access_log on;
+            return {{ route.empty_endpoint_status_code }};
+            {% endif %}
         }
         {%- endfor %}
         {%- endfor %}


### PR DESCRIPTION
Skips generation of an (invalid) empty upstream and emits a location
directive that simply returns a configurable status code.
