### PR TITLE
gevent-1.0.2 El-Capitan fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto==2.34.0
 commandr==1.3.2
 Flask-RESTful==0.3.1
-gevent==1.0.1
+gevent==1.0.2
 Jinja2==2.7.3
 kazoo==2.0
 librato-metrics==0.7.0


### PR DESCRIPTION
Mac OSX 10.11 El-Capitan 

```
   clang -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -U__llvm__ -DLIBEV_EMBED=1 -DEV_COMMON= -DEV_CLEANUP_ENABLE=0 -DEV_EMBED_ENABLE=0 -DEV_PERIODIC_ENABLE=0 -Ibuild/temp.macosx-10.10-x86_64-2.7/libev -Ilibev -I/usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c gevent/gevent.core.c -o build/temp.macosx-10.10-x86_64-2.7/gevent/gevent.core.o
    In file included from gevent/gevent.core.c:313:
    In file included from gevent/libev.h:2:
    libev/ev.c:477:48: warning: '/*' within block comment [-Wcomment]
    /*#define MIN_INTERVAL  0.00000095367431640625 /* 1/2**20, good till 2200 */
                                                   ^
    libev/ev.c:970:42: error: '_Noreturn' keyword must precede function declarator
      ecb_inline void ecb_unreachable (void) ecb_noreturn;
                                             ^~~~~~~~~~~~
      _Noreturn
    libev/ev.c:773:26: note: expanded from macro 'ecb_noreturn'
      #define ecb_noreturn   _Noreturn
                             ^
    libev/ev.c:1531:31: warning: 'extern' variable has an initializer [-Wextern-initializer]
      EV_API_DECL struct ev_loop *ev_default_loop_ptr = 0; /* needs to be initialised to make it a definition despite extern */
                                  ^
    libev/ev.c:1702:7: warning: unused variable 'ocur_' [-Wunused-variable]
          array_needsize (ANPENDING, pendings [pri], pendingmax [pri], w_->pending, EMPTY2);
          ^
    libev/ev.c:1664:22: note: expanded from macro 'array_needsize'
          int ecb_unused ocur_ = (cur);                                     \
                         ^
    libev/ev.c:1713:3: warning: unused variable 'ocur_' [-Wunused-variable]
      array_needsize (W, rfeeds, rfeedmax, rfeedcnt + 1, EMPTY2);
      ^
    libev/ev.c:1664:22: note: expanded from macro 'array_needsize'
          int ecb_unused ocur_ = (cur);                                     \
                         ^
    libev/ev.c:1840:7: warning: unused variable 'ocur_' [-Wunused-variable]
          array_needsize (int, fdchanges, fdchangemax, fdchangecnt, EMPTY2);
          ^
    libev/ev.c:1664:22: note: expanded from macro 'array_needsize'
          int ecb_unused ocur_ = (cur);                                     \
                         ^
    In file included from gevent/gevent.core.c:313:
    In file included from gevent/libev.h:2:
    In file included from libev/ev.c:2390:
    libev/ev_kqueue.c:50:3: warning: unused variable 'ocur_' [-Wunused-variable]
      array_needsize (struct kevent, kqueue_changes, kqueue_changemax, kqueue_changecnt, EMPTY2);
      ^
    libev/ev.c:1664:22: note: expanded from macro 'array_needsize'
          int ecb_unused ocur_ = (cur);                                     \
                         ^
    In file included from gevent/gevent.core.c:313:
    In file included from gevent/libev.h:2:
    In file included from libev/ev.c:2396:
    libev/ev_poll.c:66:7: warning: unused variable 'ocur_' [-Wunused-variable]
          array_needsize (struct pollfd, polls, pollmax, pollcnt, EMPTY2);
          ^
    libev/ev.c:1664:22: note: expanded from macro 'array_needsize'
          int ecb_unused ocur_ = (cur);                                     \
                         ^
    libev/ev.c:3554:34: warning: '&' within '|' [-Wbitwise-op-parentheses]
      fd_change (EV_A_ fd, w->events & EV__IOFDSET | EV_ANFD_REIFY);
                           ~~~~~~~~~~^~~~~~~~~~~~~ ~
    libev/ev.c:3554:34: note: place parentheses around the '&' expression to silence this warning
      fd_change (EV_A_ fd, w->events & EV__IOFDSET | EV_ANFD_REIFY);
                                     ^
                           (                      )
```
