### PR TITLE
Ignore system http_proxy when talking to ec2 metadata service

### DIFF
--- a/tellapart/aurproxy/register/aws.py
+++ b/tellapart/aurproxy/register/aws.py
@@ -82,7 +82,9 @@ class AwsRegisterer(BaseRegisterer):
       The value corresponding to identifier.
     """
     url = _AWS_METADATA_URI.format(identifier)
-    return requests.get(url, timeout=2).content
+    session = requests.Session()
+    session.trust_env = False  # Ignore http_proxy setting for this
+    return session.get(url, timeout=2).content
 
   def get_instance_ids(self, hosts):
     """Given a list of EC2 hosts, get a list of EC2 instance ids.


### PR DESCRIPTION
If http_proxy is set in the environment, requests will automatically respect it.  That is great if a proxy is necessary for talking to the aws API endpoints, but causes great confusion if aurproxy tries to look up
the local system's instance ID in the ec2 metadata service.  This patch fixes the outcome reflect the local machine, not the instance ID of the http proxy.
