### PR TITLE
Added libpcap-dev dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update
 # Install python prerequisites
 RUN apt-get install -y python-pip python-dev build-essential
 
-# Install go
-RUN apt-get install -y golang
+# Install go & libpcap
+RUN apt-get install -y golang libpcap-dev
 
 # Install gor
 ENV GOPATH=/opt/go


### PR DESCRIPTION
The `go get` command fails because go cannot find libpcap. Apt-getting it after grabbing golang fixes it.
