### PR TITLE
Flask-RESTful 0.3.5 update - RHEL7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto==2.34.0
 commandr==1.3.2
-Flask-RESTful==0.3.1
+Flask-RESTful==0.3.5
 gevent==1.0.2
 Jinja2==2.7.3
 kazoo==2.0


### PR DESCRIPTION
success 0.3.5 Flask-RESTful update 

```
Traceback (most recent call last):
  File "/usr/lib64/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/deploy/aurproxy/tellapart/aurproxy/command.py", line 24, in <module>
    from tellapart.aurproxy.app.module.http import lifecycle_blueprint
  File "tellapart/aurproxy/app/module/http.py", line 33, in <module>
    class QuitQuitQuit(restful.Resource):
  File "/home/deploy/aurproxy/env/lib/python2.7/site-packages/flask_restful/__init__.py", line 379, in decorator
    self.add_resource(cls, *urls, **kwargs)
  File "/home/deploy/aurproxy/env/lib/python2.7/site-packages/flask_restful/__init__.py", line 359, in add_resource
    self._register_view(self.app, resource, *urls, **kwargs)
  File "/home/deploy/aurproxy/env/lib/python2.7/site-packages/flask_restful/__init__.py", line 387, in _register_view
    if endpoint in app.view_functions.keys():
AttributeError: 'Blueprint' object has no attribute 'view_functions'
[ aurproxy]$ more /etc/redhat-release
CentOS Linux release 7.2.1511 (Core)
```
