### PR TITLE
Handle proxy ports as strings rather than integers

### DIFF
--- a/tellapart/aurproxy/backends/backend.py
+++ b/tellapart/aurproxy/backends/backend.py
@@ -72,7 +72,7 @@ class ProxyBackend(object):
 
   def _load_proxy_server(self, server):
     hosts = self._load_config_item('hosts', server, required=False)
-    ports = [ int(s) for s in
+    ports = [ str(s) for s in
               self._load_config_item('ports', server, required=True)]
     healthcheck_route = self._load_config_item('healthcheck_route',
                                                server,

--- a/tellapart/aurproxy/config/server.py
+++ b/tellapart/aurproxy/config/server.py
@@ -30,7 +30,7 @@ class ProxyServer(object):
     hosts_part = ''
     if self.hosts:
       hosts_part = '__'.join([slugify(h) for h in self.hosts])
-    ports_part = '__'.join([unicode(p) for p in self.ports])
+    ports_part = '__'.join([slugify(p) for p in self.ports])
     s = 's__'
     if hosts_part:
       s = '{0}{1}__'.format(s, hosts_part)


### PR DESCRIPTION
This enables sneaking an extra directive onto the end of the line in the nginx config, like "443 ssl".
